### PR TITLE
Fix SCORM issues with iframes

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -122,10 +122,11 @@ OPENEDX_SECRET_KEY: eHqeglW5j7T68yYtr3yL6XPz
 PLATFORM_NAME: Community Theme
 PLUGINS:
 - aicoach
-- course-about-mfe
 - community-mfe
+- course-about-mfe
 - home-mfe
 - mfe
+- scorm-fix
 - session-timeout
 PLUGIN_INDEXES:
 - https://overhang.io/tutor/main

--- a/plugins/scorm-fix.yml
+++ b/plugins/scorm-fix.yml
@@ -3,5 +3,5 @@ version: 0.1.0
 patches:
   caddyfile-lms: |
     header * {
-      Content-Security-Policy "frame-ancestors community.abzt.de *.community.abzt.de;"
+      Content-Security-Policy "frame-ancestors {{ LMS_HOST }} *.{{ LMS_HOST }};"
     }

--- a/plugins/scorm-fix.yml
+++ b/plugins/scorm-fix.yml
@@ -1,0 +1,7 @@
+name: scorm-fix
+version: 0.1.0
+patches:
+  caddyfile-lms: |
+    header * {
+      Content-Security-Policy "frame-ancestors community.abzt.de *.community.abzt.de;"
+    }


### PR DESCRIPTION
This should fix the `Refused to display 'https://community.abzt.de/' in a frame because it set 'X-Frame-Options' to 'sameorigin'.` error on the learning MFE for SCORM packages.