### PR TITLE
feat: apply recommneded settings for running open edx proxy

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -6,8 +6,9 @@ CMS_HOST: studio.local.overhang.io
 CMS_OAUTH2_SECRET: 2icx54cdu9SJ77KMlZgHTWcm
 CONTACT_EMAIL: noreply@community.abzt.de
 DOCKER_IMAGE_OPENEDX: docker.io/abstract2tech/community-theme-openedx:16.1.0
-ENABLE_HTTPS: false
-ENABLE_WEB_PROXY: true
+ENABLE_HTTPS: true
+CADDY_HTTP_PORT: 127.0.0.1:81
+ENABLE_WEB_PROXY: false
 ID: jxBish2U54zbLTe82GMVvnyO
 JWT_RSA_PRIVATE_KEY: '-----BEGIN RSA PRIVATE KEY-----
 


### PR DESCRIPTION
This relate to the infitie redirct issue that comes eveyr now and then in Chrome:;

According to [tutor docs](https://docs.tutor.overhang.io/tutorials/proxy.html) those are the correct/expected config when running behind a proxy. 

@snglth since you have changed the config before, can you take a look into this change